### PR TITLE
Release 0.3.0

### DIFF
--- a/src/api/expert/content-types/expert/schema.json
+++ b/src/api/expert/content-types/expert/schema.json
@@ -132,8 +132,7 @@
     "reviews": {
       "type": "component",
       "repeatable": true,
-      "component": "array-two-strings.review-array",
-      "max": 2
+      "component": "array-two-strings.review-array"
     },
     "additionalSpecialties": {
       "type": "component",
@@ -149,6 +148,25 @@
     "isDemo": {
       "type": "boolean",
       "default": false
+    },
+    "overview": {
+      "type": "text",
+      "required": true,
+      "maxLength": 120
+    },
+    "institutions": {
+      "type": "component",
+      "repeatable": true,
+      "component": "array-two-strings.array-images",
+      "max": 8
+    },
+    "sessionExpectations": {
+      "type": "component",
+      "repeatable": true,
+      "component": "array-two-strings.session-expectations",
+      "required": true,
+      "min": 1,
+      "max": 2
     }
   }
 }

--- a/src/components/array-two-strings/array-images.json
+++ b/src/components/array-two-strings/array-images.json
@@ -1,0 +1,22 @@
+{
+  "collectionName": "components_array_two_strings_array_images",
+  "info": {
+    "displayName": "Array-images"
+  },
+  "options": {},
+  "attributes": {
+    "institutionImage": {
+      "allowedTypes": [
+        "images",
+        "files",
+        "videos",
+        "audios"
+      ],
+      "type": "media",
+      "multiple": false
+    },
+    "institutionLink": {
+      "type": "string"
+    }
+  }
+}

--- a/src/components/array-two-strings/review-array.json
+++ b/src/components/array-two-strings/review-array.json
@@ -11,6 +11,14 @@
     },
     "reviewer": {
       "type": "string"
+    },
+    "stars": {
+      "type": "integer",
+      "required": true
+    },
+    "reviewDate": {
+      "type": "date",
+      "required": true
     }
   }
 }

--- a/src/components/array-two-strings/session-expectations.json
+++ b/src/components/array-two-strings/session-expectations.json
@@ -1,0 +1,22 @@
+{
+  "collectionName": "components_array_two_strings_session_expectations",
+  "info": {
+    "displayName": "sessionExpectations",
+    "description": ""
+  },
+  "options": {},
+  "attributes": {
+    "sessionDuration": {
+      "type": "enumeration",
+      "enum": [
+        "Thirty minute session",
+        "Sixty minute session"
+      ],
+      "required": true
+    },
+    "expectation": {
+      "type": "text",
+      "required": true
+    }
+  }
+}


### PR DESCRIPTION
- Updated expert fields: 

- session expectations -> expectation from thirty/sixty minute sessions
- reviews now include stars and a review date
- institutions field -> array of institution images and institutions links